### PR TITLE
Adjusted argument name from rules to irules

### DIFF
--- a/website/docs/r/bigip_ltm_virtual_server.html.markdown
+++ b/website/docs/r/bigip_ltm_virtual_server.html.markdown
@@ -79,7 +79,7 @@ resource "bigip_ltm_virtual_server" "https" {
 
 * `source` -  (Optional) Specifies an IP address or network from which the virtual server will accept traffic.
 
-* `rules` - (Optional) The iRules you want run on this virtual server. iRules help automate the intercepting, processing, and routing of application traffic.
+* `irules` - (Optional) The iRules you want run on this virtual server. iRules help automate the intercepting, processing, and routing of application traffic.
 
 * `snatpool` - (Optional) Specifies the name of an existing SNAT pool that you want the virtual server to use to implement selective and intelligent SNATs. DEPRECATED - see Virtual Server Property Groups source-address-translation
 


### PR DESCRIPTION
Using "rules" as an argument for a bigip_ltm_virtual_server returns the following error.

    Error: bigip_ltm_virtual_server.vip: : invalid or unknown key: rules

The correct argument name is "irules".

See the below code for reference
https://github.com/terraform-providers/terraform-provider-bigip/blob/master/bigip/resource_bigip_ltm_virtual_server.go#L102