### PR TITLE
Correct the bigip_sys_dns resource documentation (and sidebar link)

### DIFF
--- a/website/bigip.erb
+++ b/website/bigip.erb
@@ -20,9 +20,6 @@
                         <li<%= sidebar_current("docs-bigip-resource-devicegroup-x") %>>
                             <a href="/docs/providers/bigip/r/bigip_cm_devicegroup.html">bigip_cm_devicegroup</a>
                         </li>
-                        <li<%= sidebar_current("docs-bigip-resource-dns-x") %>>
-                            <a href="/docs/providers/bigip/r/bigip_sys_dns.html">bigip_ltm_dns</a>
-                        </li>
                         <li<%= sidebar_current("docs-bigip-resource-datagroup-x") %>>
                             <a href="/docs/providers/bigip/r/bigip_ltm_datagroup.html">bigip_ltm_datagroup</a>
                         </li>
@@ -97,6 +94,9 @@
                         </li>
                         <li<%= sidebar_current("docs-bigip-resource-vlan-x") %>>
                           <a href="/docs/providers/bigip/r/bigip_net_vlan.html">bigip_net_vlan</a>
+                        </li>
+                        <li<%= sidebar_current("docs-bigip-resource-dns-x") %>>
+                            <a href="/docs/providers/bigip/r/bigip_sys_dns.html">bigip_sys_dns</a>
                         </li>
                         <li<%= sidebar_current("docs-bigip-resource-iapp-x") %>>
                           <a href="/docs/providers/bigip/r/bigip_sys_iapp.html">bigip_sys_iapp</a>

--- a/website/docs/r/bigip_sys_dns.html.markdown
+++ b/website/docs/r/bigip_sys_dns.html.markdown
@@ -6,9 +6,9 @@ description: |-
     Provides details about bigip_sys_dns resource
 ---
 
-# bigip\_ltm\_dns
+# bigip\_sys\_dns
 
-`bigip_ltm_dns` Configures DNS server on F5 BIG-IP
+`bigip_sys_dns` Configures DNS server on F5 BIG-IP
 
 
 
@@ -17,10 +17,10 @@ description: |-
 
 
 ```hcl
-resource "bigip_ltm_dns" "dns1" {
+resource "bigip_sys_dns" "dns1" {
    description = "/Common/DNS1"
    name_servers = ["1.1.1.1"]
-   numberof_dots = 2
+   number_of_dots = 2
    search = ["f5.com"]
 }
 ```      


### PR DESCRIPTION
The bigip_sys_dns resource documentation specifies that the resource name is "bigip_ltm_dns", which does not match the provider behavior, nor the documentation page_title. Replaced "bigip_ltm_dns" with "bigip_sys_dns" on the page and sidebar. Also corrected a typo in the example.