### PR TITLE
Monitor: add "Computed: true" to additional optional attributes

### DIFF
--- a/bigip/resource_bigip_ltm_monitor.go
+++ b/bigip/resource_bigip_ltm_monitor.go
@@ -117,6 +117,7 @@ func resourceBigipLtmMonitor() *schema.Resource {
 			"compatibility": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				Description:  "Specifies, when enabled, that the SSL options setting (in OpenSSL) is set to ALL. The default value is enabled.",
 				ValidateFunc: validateEnabledDisabled,
 			},
@@ -128,6 +129,7 @@ func resourceBigipLtmMonitor() *schema.Resource {
 			"mode": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Specifies the data transfer process (DTP) mode. The default value is passive.",
 			},
 			"adaptive": {


### PR DESCRIPTION
Few more optional parameters require the `Computed: true` parameter to ensure they are retrieved after creating the resource.

specifically I was having an issue with `compatibility`

```
  ~ bigip_ltm_monitor.kube_apiserver
      compatibility: "enabled" => ""
```

it defaults to `enabled`, but the provider tries to nullify it.

/cc @scshitole 