### PR TITLE
Fix VS and Node Read functions

### DIFF
--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -63,8 +63,8 @@ func resourceBigipLtmNode() *schema.Resource {
 			"state": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "user-up",
 				Description: "Marks the node up or down. The default value is user-up.",
+				Computed:    true,
 			},
 			"fqdn": {
 				Type:     schema.TypeList,
@@ -199,6 +199,7 @@ func resourceBigipLtmNodeRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[DEBUG] Error saving Monitor to state for Node (%s): %s", d.Id(), err)
 	}
 
+	d.Set("state", node.State)
 	d.Set("connection_limit", node.ConnectionLimit)
 	d.Set("dynamic_ratio", node.DynamicRatio)
 	d.Set("fqdn.0.interval", node.FQDN.Interval)


### PR DESCRIPTION
This PR fixes a couple of problem with Read function for VS and Node resources.

1) Virtual Server `port` attribute was incorrectly retrieved from `SourcePort` parameter, which is unrelated. The service port is returned by the API in the `destination` parameter.

2) Node `state` attribute was not refreshed as part of Read, I also changed it to `Computed: true` instead of hard coding a default.

/cc @scshitole 