### PR TITLE
Add Node/Virtualserver with Routedomain

### DIFF
--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -155,6 +155,10 @@ func mapEntity(d map[string]interface{}, obj interface{}) {
 				f.Set(reflect.ValueOf(d[field]))
 			}
 		} else {
+			if field == "http_reply" {
+				f := val.FieldByName(strings.Title("httpReply"))
+				f.Set(reflect.ValueOf(d[field]))
+			}
 			log.Printf("[WARN] You probably weren't expecting %s to be an invalid field", field)
 		}
 	}

--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -187,7 +187,7 @@ func resourceBigipLtmNodeRead(d *schema.ResourceData, meta interface{}) error {
 		// xxx.xxx.xxx.xxx(%x)
 		regex := regexp.MustCompile(`((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?:\%\d+)?`)
 		address := regex.FindStringSubmatch(node.Address)
-	        log.Println("[INFO] Address: " + address[1])
+		log.Println("[INFO] Address: " + address[1])
 		if err := d.Set("address", node.Address); err != nil {
 			return fmt.Errorf("[DEBUG] Error saving address to state for Node (%s): %s", d.Id(), err)
 		}

--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -187,7 +187,8 @@ func resourceBigipLtmNodeRead(d *schema.ResourceData, meta interface{}) error {
 		// xxx.xxx.xxx.xxx(%x)
 		regex := regexp.MustCompile(`((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?:\%\d+)?`)
 		address := regex.FindStringSubmatch(node.Address)
-		if err := d.Set("address", address[1]); err != nil {
+	        log.Println("[INFO] Address: " + address[1])
+		if err := d.Set("address", node.Address); err != nil {
 			return fmt.Errorf("[DEBUG] Error saving address to state for Node (%s): %s", d.Id(), err)
 		}
 	}

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -34,7 +34,7 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 				Required:    true,
 				Description: "Listen port for the virtual server",
 			},
-			
+
 			"source": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -34,7 +34,7 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 				Required:    true,
 				Description: "Listen port for the virtual server",
 			},
-
+			
 			"source": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -215,20 +215,21 @@ func resourceBigipLtmVirtualServerRead(d *schema.ResourceData, meta interface{})
 		return nil
 	}
 	// Extract destination address from "/partition_name/(virtual_server_address)[%route_domain]:port"
-	regex := regexp.MustCompile(`(\/.+\/)((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?:\%\d+)?(\:\d+)`)
+	regex := regexp.MustCompile(`(\/.+\/)((?:[0-9]{1,3}\.){3}[0-9]{1,3})(\%\d+)?(\:\d+)`)
 	destination := regex.FindStringSubmatch(vs.Destination)
+	parsedDestination := destination[2] + destination[3]
 	if len(destination) < 3 {
 		return fmt.Errorf("Unable to extract destination address from virtual server destination: " + vs.Destination)
 	}
-	if err := d.Set("destination", destination[2]); err != nil {
+	if err := d.Set("destination", parsedDestination); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Destination to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
 
 	// Extract source address from "(source_address)[%route_domain](/mask)" groups 1 + 2
-	regex = regexp.MustCompile(`((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?:\%\d+)?(\/\d+)`)
-	source := regex.FindStringSubmatch(vs.Source)
-	parsedSource := source[1] + source[2]
-	if err := d.Set("source", parsedSource); err != nil {
+	//regex = regexp.MustCompile(`((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?:\%\d+)?(\/\d+)`)
+	//source := regex.FindStringSubmatch(vs.Source)
+	//parsedSource := source[1] + source[2]
+	if err := d.Set("source", vs.Source); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Source to state for Virtual Server  (%s): %s", d.Id(), err)
 	}
 


### PR DESCRIPTION
Acceptance Test results:

root@terraformclient:~/Go_Workspace/src/github.com/terraform-providers/terraform-provider-bigip# BIGIP_USER=admin BIGIP_PASSWORD=F5site02 BIGIP_HOST=10.145.67.133 TF_ACC=1 go test ./bigip -v -run=Test*
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.00s)
=== RUN   TestAccBigipCmDevice_create
--- PASS: TestAccBigipCmDevice_create (0.65s)
=== RUN   TestAccBigipCmDevice_import
--- PASS: TestAccBigipCmDevice_import (2.62s)
=== RUN   TestAccBigipCmDevicegroup_create
--- PASS: TestAccBigipCmDevicegroup_create (1.68s)
=== RUN   TestAccBigipCmDevicegroup_import
--- PASS: TestAccBigipCmDevicegroup_import (0.74s)
=== RUN   TestAccBigipLtmDataGroup_create
--- PASS: TestAccBigipLtmDataGroup_create (3.01s)
=== RUN   TestAccBigipLtmDataGroup_import
--- PASS: TestAccBigipLtmDataGroup_import (1.93s)
=== RUN   TestAccBigipLtmIRule_create
--- PASS: TestAccBigipLtmIRule_create (0.77s)
=== RUN   TestAccBigipLtmIRule_import
--- PASS: TestAccBigipLtmIRule_import (1.02s)
=== RUN   TestAccBigipLtmMonitor_create
--- PASS: TestAccBigipLtmMonitor_create (3.62s)
=== RUN   TestAccBigipLtmMonitor_import
--- PASS: TestAccBigipLtmMonitor_import (1.10s)
=== RUN   TestAccBigipLtmNode_create
--- PASS: TestAccBigipLtmNode_create (0.89s)
=== RUN   TestAccBigipLtmNode_import
--- PASS: TestAccBigipLtmNode_import (1.11s)
=== RUN   TestAccBigipLtmNodeInvalid
--- PASS: TestAccBigipLtmNodeInvalid (0.01s)
=== RUN   TestAccBigipLtmNodeCreate
--- PASS: TestAccBigipLtmNodeCreate (0.09s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieCreate
--- PASS: TestAccBigipLtmPersistenceProfileCookieCreate (1.01s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieImport
--- PASS: TestAccBigipLtmPersistenceProfileCookieImport (1.00s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrCreate (0.63s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrImport (0.64s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrCreate (0.93s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrImport (0.83s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLCreate
--- PASS: TestAccBigipLtmPersistenceProfileSSLCreate (0.96s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLImport
--- PASS: TestAccBigipLtmPersistenceProfileSSLImport (0.85s)
=== RUN   TestAccBigipLtmPolicy_create
--- PASS: TestAccBigipLtmPolicy_create (1.17s)
=== RUN   TestAccBigipLtmPolicy_import
--- PASS: TestAccBigipLtmPolicy_import (1.23s)
=== RUN   TestAccBigipLtmPool_create
--- PASS: TestAccBigipLtmPool_create (0.82s)
=== RUN   TestAccBigipLtmPool_import
--- PASS: TestAccBigipLtmPool_import (0.90s)
=== RUN   TestAccBigipLtmfasthttp_create
--- PASS: TestAccBigipLtmfasthttp_create (0.98s)
=== RUN   TestAccBigipLtmProfilefasthttp_import
--- PASS: TestAccBigipLtmProfilefasthttp_import (1.04s)
=== RUN   TestAccBigipLtmProfileFastl4_create
--- PASS: TestAccBigipLtmProfileFastl4_create (0.48s)
=== RUN   TestAccBigipLtmProfileFastl4_import
--- PASS: TestAccBigipLtmProfileFastl4_import (0.91s)
=== RUN   TestAccBigipLtmProfileHttp2_create
--- PASS: TestAccBigipLtmProfileHttp2_create (0.48s)
=== RUN   TestAccBigipLtmProfileHttp2_import
--- PASS: TestAccBigipLtmProfileHttp2_import (0.44s)
=== RUN   TestAccBigipLtmProfilehttp_create
--- PASS: TestAccBigipLtmProfilehttp_create (0.58s)
=== RUN   TestAccBigipLtmProfilehttp_import
--- PASS: TestAccBigipLtmProfilehttp_import (0.55s)
=== RUN   TestAccBigipLtmProfileHttpcompress_create
--- PASS: TestAccBigipLtmProfileHttpcompress_create (0.64s)
=== RUN   TestAccBigipLtmProfileHttpcompress_import
--- PASS: TestAccBigipLtmProfileHttpcompress_import (0.46s)
=== RUN   TestAccBigipLtmProfileoneconnect_create
--- PASS: TestAccBigipLtmProfileoneconnect_create (0.51s)
=== RUN   TestAccBigipLtmProfileoneconnect_import
--- PASS: TestAccBigipLtmProfileoneconnect_import (0.70s)
=== RUN   TestAccBigipLtmProfileTcp_create
--- PASS: TestAccBigipLtmProfileTcp_create (0.63s)
=== RUN   TestAccBigipLtmProfileTcp_import
--- PASS: TestAccBigipLtmProfileTcp_import (0.47s)
=== RUN   TestAccBigipLtmsnat_create
--- PASS: TestAccBigipLtmsnat_create (0.43s)
=== RUN   TestAccBigipLtmsnat_import
--- PASS: TestAccBigipLtmsnat_import (0.44s)
=== RUN   TestAccBigipLtmsnatpool_create
--- PASS: TestAccBigipLtmsnatpool_create (0.47s)
=== RUN   TestAccBigipLtmsnatpool_import
--- PASS: TestAccBigipLtmsnatpool_import (0.44s)
=== RUN   TestAccBigipLtmVA_create
--- PASS: TestAccBigipLtmVA_create (0.53s)
=== RUN   TestAccBigipLtmVA_import
--- PASS: TestAccBigipLtmVA_import (0.46s)
=== RUN   TestAccBigipLtmVS_create
--- PASS: TestAccBigipLtmVS_create (1.45s)
=== RUN   TestAccBigipLtmVS_import
--- PASS: TestAccBigipLtmVS_import (1.03s)
=== RUN   TestAccBigipNetroute_create
--- PASS: TestAccBigipNetroute_create (0.98s)
=== RUN   TestAccBigipNetroute_import
--- PASS: TestAccBigipNetroute_import (0.90s)
=== RUN   TestAccBigipNetselfip_create
--- PASS: TestAccBigipNetselfip_create (1.06s)
=== RUN   TestAccBigipNetselfip_import
--- PASS: TestAccBigipNetselfip_import (2.02s)
=== RUN   TestAccBigipNetvlan_create
--- PASS: TestAccBigipNetvlan_create (2.53s)
=== RUN   TestAccBigipNetvlan_import
--- PASS: TestAccBigipNetvlan_import (2.63s)
=== RUN   TestAccBigipSysdns_create
--- PASS: TestAccBigipSysdns_create (0.58s)
=== RUN   TestAccBigipSysdns_import
--- PASS: TestAccBigipSysdns_import (0.46s)
=== RUN   TestAccBigipSysIapp_create
--- PASS: TestAccBigipSysIapp_create (0.85s)
=== RUN   TestAccBigipSysIapp_import
--- PASS: TestAccBigipSysIapp_import (0.81s)
=== RUN   TestAccBigipSysNtp_create
--- PASS: TestAccBigipSysNtp_create (0.44s)
=== RUN   TestAccBigipSysNtp_import
--- PASS: TestAccBigipSysNtp_import (0.46s)
=== RUN   TestAccBigipSysNtpInvalid
--- PASS: TestAccBigipSysNtpInvalid (0.01s)
=== RUN   TestAccBigipSysProvision_create
--- PASS: TestAccBigipSysProvision_create (0.36s)
=== RUN   TestAccBigipSysProvision_import
--- PASS: TestAccBigipSysProvision_import (0.32s)
=== RUN   TestAccBigipSyssnmp_create
--- PASS: TestAccBigipSyssnmp_create (0.60s)
=== RUN   TestAccBigipSyssnmp_import
--- PASS: TestAccBigipSyssnmp_import (0.55s)
=== RUN   TestValidStringValue
--- PASS: TestValidStringValue (0.00s)
=== RUN   TestInvalidStringValue
--- PASS: TestInvalidStringValue (0.00s)
=== RUN   TestF5NameString
--- PASS: TestF5NameString (0.00s)
=== RUN   TestF5NameSet
--- PASS: TestF5NameSet (0.00s)
=== RUN   TestF5NameList
--- PASS: TestF5NameList (0.00s)
=== RUN   TestValidateEnabledDisabledString
--- PASS: TestValidateEnabledDisabledString (0.00s)
=== RUN   TestValidateReqPrefDisabledString
--- PASS: TestValidateReqPrefDisabledString (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-bigip/bigip   59.954s
