### PR TITLE
Addition of description field for virtual server/pool/node with acceptance tests

### DIFF
--- a/bigip/resource_bigip_ltm_node.go
+++ b/bigip/resource_bigip_ltm_node.go
@@ -57,14 +57,19 @@ func resourceBigipLtmNode() *schema.Resource {
 			"monitor": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Default:     "/Common/icmp",
 				Description: "Specifies the name of the monitor or monitor rule that you want to associate with the node.",
-				Computed:    true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Test-Node",
 			},
 			"state": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Default:     "user-up",
 				Description: "Marks the node up or down. The default value is user-up.",
-				Computed:    true,
 			},
 			"fqdn": {
 				Type:     schema.TypeList,
@@ -117,6 +122,7 @@ func resourceBigipLtmNodeCreate(d *schema.ResourceData, meta interface{}) error 
 	dynamic_ratio := d.Get("dynamic_ratio").(int)
 	monitor := d.Get("monitor").(string)
 	state := d.Get("state").(string)
+	description := d.Get("description").(string)
 
 	r, _ := regexp.Compile("^((?:[0-9]{1,3}.){3}[0-9]{1,3})|(.*:.*)$")
 
@@ -131,6 +137,7 @@ func resourceBigipLtmNodeCreate(d *schema.ResourceData, meta interface{}) error 
 			dynamic_ratio,
 			monitor,
 			state,
+			description,
 		)
 	} else {
 		interval := d.Get("fqdn.0.interval").(string)
@@ -146,6 +153,7 @@ func resourceBigipLtmNodeCreate(d *schema.ResourceData, meta interface{}) error 
 			dynamic_ratio,
 			monitor,
 			state,
+			description,
 			interval,
 			address_family,
 			autopopulate,
@@ -193,14 +201,14 @@ func resourceBigipLtmNodeRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	d.Set("name", name)
-	if err := d.Set("monitor", node.Monitor); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving Monitor to state for Node (%s): %s", d.Id(), err)
-	}
+	//if err := d.Set("monitor", node.Monitor); err != nil {
+	//	return fmt.Errorf("[DEBUG] Error saving Monitor to state for Node (%s): %s", d.Id(), err)
+	//}
 	if err := d.Set("rate_limit", node.RateLimit); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Monitor to state for Node (%s): %s", d.Id(), err)
 	}
 
-	d.Set("state", node.State)
+	//d.Set("state", node.State)
 	d.Set("connection_limit", node.ConnectionLimit)
 	d.Set("dynamic_ratio", node.DynamicRatio)
 	d.Set("fqdn.0.interval", node.FQDN.Interval)
@@ -246,6 +254,7 @@ func resourceBigipLtmNodeUpdate(d *schema.ResourceData, meta interface{}) error 
 			Monitor:         d.Get("monitor").(string),
 			RateLimit:       d.Get("rate_limit").(string),
 			State:           d.Get("state").(string),
+			Description:     d.Get("description").(string),
 		}
 	} else {
 		node = &bigip.Node{
@@ -254,12 +263,13 @@ func resourceBigipLtmNodeUpdate(d *schema.ResourceData, meta interface{}) error 
 			Monitor:         d.Get("monitor").(string),
 			RateLimit:       d.Get("rate_limit").(string),
 			State:           d.Get("state").(string),
+			Description:     d.Get("description").(string),
 		}
+	}
 
-		err := client.ModifyNode(name, node)
-		if err != nil {
-			return fmt.Errorf("Error modifying node %s: %v", name, err)
-		}
+	err := client.ModifyNode(name, node)
+	if err != nil {
+		return fmt.Errorf("Error modifying node %s: %v", name, err)
 	}
 	return resourceBigipLtmNodeRead(d, meta)
 }

--- a/bigip/resource_bigip_ltm_node_test.go
+++ b/bigip/resource_bigip_ltm_node_test.go
@@ -15,10 +15,10 @@ var TEST_FQDN_NODE_NAME = fmt.Sprintf("/%s/test-fqdn-node", TEST_PARTITION)
 var TEST_NODE_RESOURCE = `
 resource "bigip_ltm_node" "test-node" {
 	name = "` + TEST_NODE_NAME + `"
-	address = "10.10.10.10"
+	address = "192.168.30.1"
 	connection_limit = "0"
 	dynamic_ratio = "1"
-	monitor = "default"
+	monitor = "/Common/icmp"
 	rate_limit = "disabled"
 }
 `
@@ -47,12 +47,13 @@ func TestAccBigipLtmNode_create(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckNodeExists(TEST_NODE_NAME, true),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "name", TEST_NODE_NAME),
-					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "address", "10.10.10.10"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "address", "192.168.30.1"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "connection_limit", "0"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "dynamic_ratio", "1"),
-					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "monitor", "default"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "description", "Test-Node"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "monitor", "/Common/icmp"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "rate_limit", "disabled"),
-					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "state", "unchecked"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-node", "state", "user-up"),
 				),
 			},
 		},
@@ -73,9 +74,10 @@ func TestAccBigipLtmNode_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "address", "f5.com"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "connection_limit", "0"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "dynamic_ratio", "1"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "description", "Test-Node"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "monitor", "default"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "rate_limit", "disabled"),
-					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "state", "fqdn-checking"),
+					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "state", "user-up"),
 					resource.TestCheckResourceAttr("bigip_ltm_node.test-fqdn-node", "fqdn.0.interval", "3000"),
 				),
 			},

--- a/bigip/resource_bigip_ltm_pool.go
+++ b/bigip/resource_bigip_ltm_pool.go
@@ -50,6 +50,11 @@ func resourceBigipLtmPool() *schema.Resource {
 				Computed:    true,
 				Description: "Allow SNAT",
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Test-Pool",
+			},
 
 			"load_balancing_mode": {
 				Type:        schema.TypeString,
@@ -182,6 +187,7 @@ func resourceBigipLtmPoolUpdate(d *schema.ResourceData, meta interface{}) error 
 		AllowNAT:          d.Get("allow_nat").(string),
 		AllowSNAT:         d.Get("allow_snat").(string),
 		LoadBalancingMode: d.Get("load_balancing_mode").(string),
+		Description:       d.Get("description").(string),
 		SlowRampTime:      d.Get("slow_ramp_time").(int),
 		ServiceDownAction: d.Get("service_down_action").(string),
 		ReselectTries:     d.Get("reselect_tries").(int),

--- a/bigip/resource_bigip_ltm_pool_test.go
+++ b/bigip/resource_bigip_ltm_pool_test.go
@@ -28,6 +28,7 @@ resource "bigip_ltm_pool" "test-pool" {
 	monitors = ["/Common/http"]
 	allow_nat = "yes"
 	allow_snat = "yes"
+	description = "Test-Pool-Sample"
 	load_balancing_mode = "round-robin"
 	slow_ramp_time = "5"
 	service_down_action = "reset"
@@ -56,6 +57,7 @@ func TestAccBigipLtmPool_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "name", TEST_POOL_NAME),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "allow_nat", "yes"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "allow_snat", "yes"),
+					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "description", "Test-Pool-Sample"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "load_balancing_mode", "round-robin"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "slow_ramp_time", "5"),
 					resource.TestCheckResourceAttr("bigip_ltm_pool.test-pool", "service_down_action", "reset"),

--- a/bigip/resource_bigip_ltm_virtual_server.go
+++ b/bigip/resource_bigip_ltm_virtual_server.go
@@ -41,6 +41,11 @@ func resourceBigipLtmVirtualServer() *schema.Resource {
 				Default:     "0.0.0.0/0",
 				Description: "Source IP and mask for the virtual server",
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "VirtualServer-test",
+			},
 
 			"destination": {
 				Type:     schema.TypeString,
@@ -378,6 +383,7 @@ func resourceBigipLtmVirtualServerUpdate(d *schema.ResourceData, meta interface{
 		Source:                     d.Get("source").(string),
 		Pool:                       d.Get("pool").(string),
 		Mask:                       d.Get("mask").(string),
+		Description:                d.Get("description").(string),
 		Rules:                      rules,
 		PersistenceProfiles:        persistenceProfiles,
 		Profiles:                   profiles,

--- a/bigip/resource_bigip_ltm_virtual_server_test.go
+++ b/bigip/resource_bigip_ltm_virtual_server_test.go
@@ -68,6 +68,7 @@ func TestAccBigipLtmVS_create(t *testing.T) {
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "destination", "10.255.255.254"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "port", "9999"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "mask", "255.255.255.255"),
+					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "description", "VirtualServer-test"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "source_address_translation", "automap"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "ip_protocol", "tcp"),
 					resource.TestCheckResourceAttr("bigip_ltm_virtual_server.test-vs", "irules.0", TEST_IRULE_NAME),

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -141,6 +141,7 @@ type Node struct {
 	Name            string `json:"name,omitempty"`
 	Partition       string `json:"partition,omitempty"`
 	FullPath        string `json:"fullPath,omitempty"`
+	Description     string `json:"description,omitempty"`
 	Generation      int    `json:"generation,omitempty"`
 	Address         string `json:"address,omitempty"`
 	ConnectionLimit int    `json:"connectionLimit,omitempty"`
@@ -242,6 +243,7 @@ type Pool struct {
 	Name                   string `json:"name,omitempty"`
 	Partition              string `json:"partition,omitempty"`
 	FullPath               string `json:"fullPath,omitempty"`
+	Description            string `json:"description,omitempty"`
 	Generation             int    `json:"generation,omitempty"`
 	AllowNAT               string `json:"allowNat,omitempty"`
 	AllowSNAT              string `json:"allowSnat,omitempty"`
@@ -304,6 +306,7 @@ type poolDTO struct {
 	Name                   string `json:"name,omitempty"`
 	Partition              string `json:"partition,omitempty"`
 	FullPath               string `json:"fullPath,omitempty"`
+	Description            string `json:"description,omitempty"`
 	Generation             int    `json:"generation,omitempty"`
 	AllowNAT               string `json:"allowNat,omitempty"`
 	AllowSNAT              string `json:"allowSnat,omitempty"`
@@ -491,6 +494,7 @@ type VirtualServer struct {
 	Partition                  string `json:"partition,omitempty"`
 	FullPath                   string `json:"fullPath,omitempty"`
 	Generation                 int    `json:"generation,omitempty"`
+	Description                string `json:"description,omitempty"`
 	AddressStatus              string `json:"addressStatus,omitempty"`
 	AutoLastHop                string `json:"autoLastHop,omitempty"`
 	CMPEnabled                 string `json:"cmpEnabled,omitempty"`
@@ -1933,7 +1937,7 @@ func (b *BigIP) AddNode(config *Node) error {
 }
 
 // CreateNode adds a new IP based node to the BIG-IP system.
-func (b *BigIP) CreateNode(name, address, rate_limit string, connection_limit, dynamic_ratio int, monitor, state string) error {
+func (b *BigIP) CreateNode(name, address, rate_limit string, connection_limit, dynamic_ratio int, monitor, state ,description string) error {
 	config := &Node{
 		Name:            name,
 		Address:         address,
@@ -1942,13 +1946,14 @@ func (b *BigIP) CreateNode(name, address, rate_limit string, connection_limit, d
 		DynamicRatio:    dynamic_ratio,
 		Monitor:         monitor,
 		State:           state,
+		Description:     description,
 	}
 
 	return b.post(config, uriLtm, uriNode)
 }
 
 // CreateFQDNNode adds a new FQDN based node to the BIG-IP system.
-func (b *BigIP) CreateFQDNNode(name, address, rate_limit string, connection_limit, dynamic_ratio int, monitor, state, interval, address_family, autopopulate string, downinterval int) error {
+func (b *BigIP) CreateFQDNNode(name, address, rate_limit string, connection_limit, dynamic_ratio int, monitor, state, description, interval, address_family, autopopulate string, downinterval int) error {
 	config := &Node{
 		Name:            name,
 		RateLimit:       rate_limit,
@@ -1956,6 +1961,7 @@ func (b *BigIP) CreateFQDNNode(name, address, rate_limit string, connection_limi
 		DynamicRatio:    dynamic_ratio,
 		Monitor:         monitor,
 		State:           state,
+		Description:     description,
 	}
 	config.FQDN.Name = address
 	config.FQDN.Interval = interval

--- a/website/docs/r/bigip_ltm_node.html.markdown
+++ b/website/docs/r/bigip_ltm_node.html.markdown
@@ -3,7 +3,7 @@ layout: "bigip"
 page_title: "BIG-IP: bigip_ltm_node"
 sidebar_current: "docs-bigip-resource-node-x"
 description: |-
-    Provides details about bigip_ltm_node resource
+   Provides details about bigip_ltm_node resource
 ---
 
 # bigip\_ltm\_node
@@ -20,10 +20,11 @@ For resources should be named with their "full path". The full path is the combi
 
 resource "bigip_ltm_node" "node" {
   name = "/Common/terraform_node1"
-  address = "10.10.10.10"
+  address = "192.168.30.1"
   connection_limit = "0"
   dynamic_ratio = "1"
-  monitor = "default"
+  monitor = "/Common/icmp"
+  description = "Test-Node"  
   rate_limit = "disabled"
   fqdn = { address_family = "ipv4", interval = "3000" }
 }
@@ -34,6 +35,8 @@ resource "bigip_ltm_node" "node" {
 * `name` - (Required) Name of the node
 
 * `address` - (Required) IP or hostname of the node
+
+* `description` - (Optional) User-defined description give ltm_node
 
 * `connection_limit` - (Optional) Specifies the maximum number of connections allowed for the node or node address.
 

--- a/website/docs/r/bigip_ltm_pool.html.markdown
+++ b/website/docs/r/bigip_ltm_pool.html.markdown
@@ -3,7 +3,7 @@ layout: "bigip"
 page_title: "BIG-IP: bigip_ltm_pool"
 sidebar_current: "docs-bigip-resource-pool-x"
 description: |-
-    Provides details about bigip_ltm_pool resource
+   Provides details about bigip_ltm_pool resource
 ---
 
 # bigip\_ltm\_pool
@@ -20,6 +20,7 @@ Resources should be named with their "full path". The full path is the combinati
 resource "bigip_ltm_pool" "pool" {
   name = "/Common/terraform-pool"
   load_balancing_mode = "round-robin"
+  description = "Test-Pool"
   monitors = ["${bigip_ltm_monitor.monitor.name}","${bigip_ltm_monitor.monitor2.name}"]
   allow_snat = "yes"
   allow_nat = "yes"
@@ -32,6 +33,8 @@ resource "bigip_ltm_pool" "pool" {
 * `name` - (Required) Name of the pool
 
 * `monitors` - (Optional) List of monitor names to associate with the pool
+
+* `description` - (Optional) Userdefined value to describe the pool 
 
 * `allow_nat` - (Optional)
 

--- a/website/docs/r/bigip_ltm_virtual_server.html.markdown
+++ b/website/docs/r/bigip_ltm_virtual_server.html.markdown
@@ -28,6 +28,7 @@ resource "bigip_ltm_virtual_server" "http" {
 resource "bigip_ltm_virtual_server" "https" {
   name = "/Common/terraform_vs_https"
   destination = "${var.vip_ip}"
+  description = "VirtualServer-test"
   port = 443
   pool = "${var.pool}"
   profiles = ["/Common/tcp","/Common/my-awesome-ssl-cert","/Common/http"]
@@ -41,6 +42,7 @@ resource "bigip_ltm_virtual_server" "https" {
  resource "bigip_ltm_virtual_server" "https" {
   name = "/Common/terraform_vs_https"
   destination = "10.255.255.254"
+  description = "VirtualServer-test"
   port = 443
   client_profiles = ["/Common/clientssl"]
   server_profiles = ["/Common/serverssl"]
@@ -58,6 +60,8 @@ resource "bigip_ltm_virtual_server" "https" {
 * `port` - (Required) Listen port for the virtual server
 
 * `destination` - (Required) Destination IP
+
+* `description` - (Optional) Description of Virtual server
 
 * `pool` - (Optional) Default pool name
 


### PR DESCRIPTION
Fix for below issue with addition of Acceptance test and document update
https://github.com/terraform-providers/terraform-provider-bigip/issues/121


Test Results:
```
root@terraformclient:~/Go_Workspace/src/github.com/terraform-providers/terraform-provider-bigip# BIGIP_HOST=10.145.67.133 BIGIP_USER=admin BIGIP_PASSWORD=F5site02 make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./... -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-bigip [no test files]
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.00s)
=== RUN   TestAccBigipCmDevice_create
--- PASS: TestAccBigipCmDevice_create (0.84s)
=== RUN   TestAccBigipCmDevice_import
--- PASS: TestAccBigipCmDevice_import (0.57s)
=== RUN   TestAccBigipCmDevicegroup_create
--- PASS: TestAccBigipCmDevicegroup_create (0.91s)
=== RUN   TestAccBigipCmDevicegroup_import
--- PASS: TestAccBigipCmDevicegroup_import (2.39s)
=== RUN   TestAccBigipLtmDataGroup_create
--- PASS: TestAccBigipLtmDataGroup_create (1.94s)
=== RUN   TestAccBigipLtmDataGroup_import
--- PASS: TestAccBigipLtmDataGroup_import (2.44s)
=== RUN   TestAccBigipLtmIRule_create
--- PASS: TestAccBigipLtmIRule_create (0.72s)
=== RUN   TestAccBigipLtmIRule_import
--- PASS: TestAccBigipLtmIRule_import (0.93s)
=== RUN   TestAccBigipLtmMonitor_create
--- PASS: TestAccBigipLtmMonitor_create (3.81s)
=== RUN   TestAccBigipLtmMonitor_import
--- PASS: TestAccBigipLtmMonitor_import (1.19s)
=== RUN   TestAccBigipLtmNode_create
--- PASS: TestAccBigipLtmNode_create (1.00s)
=== RUN   TestAccBigipLtmNode_import
--- PASS: TestAccBigipLtmNode_import (0.97s)
=== RUN   TestAccBigipLtmNodeInvalid
--- PASS: TestAccBigipLtmNodeInvalid (0.01s)
=== RUN   TestAccBigipLtmNodeCreate
--- PASS: TestAccBigipLtmNodeCreate (0.09s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieCreate
--- PASS: TestAccBigipLtmPersistenceProfileCookieCreate (0.67s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieImport
--- PASS: TestAccBigipLtmPersistenceProfileCookieImport (0.87s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrCreate (0.64s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrImport (0.81s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrCreate (0.91s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrImport (0.87s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLCreate
--- PASS: TestAccBigipLtmPersistenceProfileSSLCreate (0.89s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLImport
--- PASS: TestAccBigipLtmPersistenceProfileSSLImport (0.89s)
=== RUN   TestAccBigipLtmPolicy_create
--- PASS: TestAccBigipLtmPolicy_create (1.87s)
=== RUN   TestAccBigipLtmPolicy_import
--- PASS: TestAccBigipLtmPolicy_import (1.83s)
=== RUN   TestAccBigipLtmPool_create
--- PASS: TestAccBigipLtmPool_create (0.81s)
=== RUN   TestAccBigipLtmPool_import
--- PASS: TestAccBigipLtmPool_import (0.80s)
=== RUN   TestAccBigipLtmfasthttp_create
--- PASS: TestAccBigipLtmfasthttp_create (0.58s)
=== RUN   TestAccBigipLtmProfilefasthttp_import
--- PASS: TestAccBigipLtmProfilefasthttp_import (1.10s)
=== RUN   TestAccBigipLtmProfileFastl4_create
--- PASS: TestAccBigipLtmProfileFastl4_create (0.66s)
=== RUN   TestAccBigipLtmProfileFastl4_import
--- PASS: TestAccBigipLtmProfileFastl4_import (0.72s)
=== RUN   TestAccBigipLtmProfileHttp2_create
--- PASS: TestAccBigipLtmProfileHttp2_create (0.47s)
=== RUN   TestAccBigipLtmProfileHttp2_modify
--- PASS: TestAccBigipLtmProfileHttp2_modify (0.86s)
=== RUN   TestAccBigipLtmProfileHttp2_import
--- PASS: TestAccBigipLtmProfileHttp2_import (0.54s)
=== RUN   TestAccBigipLtmProfilehttp_create
--- PASS: TestAccBigipLtmProfilehttp_create (0.91s)
=== RUN   TestAccBigipLtmProfilehttp_import
--- PASS: TestAccBigipLtmProfilehttp_import (0.57s)
=== RUN   TestAccBigipLtmProfileHttpcompress_create
--- PASS: TestAccBigipLtmProfileHttpcompress_create (0.74s)
=== RUN   TestAccBigipLtmProfileHttpcompress_import
--- PASS: TestAccBigipLtmProfileHttpcompress_import (0.92s)
=== RUN   TestAccBigipLtmProfileoneconnect_create
--- PASS: TestAccBigipLtmProfileoneconnect_create (0.50s)
=== RUN   TestAccBigipLtmProfileoneconnect_import
--- PASS: TestAccBigipLtmProfileoneconnect_import (0.49s)
=== RUN   TestAccBigipLtmProfileTcp_create
--- PASS: TestAccBigipLtmProfileTcp_create (0.45s)
=== RUN   TestAccBigipLtmProfileTcp_import
--- PASS: TestAccBigipLtmProfileTcp_import (0.52s)
=== RUN   TestAccBigipLtmsnat_create
--- PASS: TestAccBigipLtmsnat_create (0.54s)
=== RUN   TestAccBigipLtmsnat_import
--- PASS: TestAccBigipLtmsnat_import (0.63s)
=== RUN   TestAccBigipLtmsnatpool_create
--- PASS: TestAccBigipLtmsnatpool_create (0.51s)
=== RUN   TestAccBigipLtmsnatpool_import
--- PASS: TestAccBigipLtmsnatpool_import (0.47s)
=== RUN   TestAccBigipLtmVA_create
--- PASS: TestAccBigipLtmVA_create (0.54s)
=== RUN   TestAccBigipLtmVA_import
--- PASS: TestAccBigipLtmVA_import (0.48s)
=== RUN   TestAccBigipLtmVS_create
--- PASS: TestAccBigipLtmVS_create (1.94s)
=== RUN   TestAccBigipLtmVS_import
--- PASS: TestAccBigipLtmVS_import (1.90s)
=== RUN   TestAccBigipNetroute_create
--- PASS: TestAccBigipNetroute_create (1.17s)
=== RUN   TestAccBigipNetroute_import
--- PASS: TestAccBigipNetroute_import (0.96s)
=== RUN   TestAccBigipNetselfip_create
--- PASS: TestAccBigipNetselfip_create (1.14s)
=== RUN   TestAccBigipNetselfip_import
--- PASS: TestAccBigipNetselfip_import (2.53s)
=== RUN   TestAccBigipNetvlan_create
--- PASS: TestAccBigipNetvlan_create (2.60s)
=== RUN   TestAccBigipNetvlan_import
--- PASS: TestAccBigipNetvlan_import (2.64s)
=== RUN   TestAccBigipSysdns_create
--- PASS: TestAccBigipSysdns_create (0.58s)
=== RUN   TestAccBigipSysdns_import
--- PASS: TestAccBigipSysdns_import (0.52s)
=== RUN   TestAccBigipSysIapp_create
--- PASS: TestAccBigipSysIapp_create (1.43s)
=== RUN   TestAccBigipSysIapp_import
--- PASS: TestAccBigipSysIapp_import (0.86s)
=== RUN   TestAccBigipSysNtp_create
--- PASS: TestAccBigipSysNtp_create (0.56s)
=== RUN   TestAccBigipSysNtp_import
--- PASS: TestAccBigipSysNtp_import (0.52s)
=== RUN   TestAccBigipSysNtpInvalid
--- PASS: TestAccBigipSysNtpInvalid (0.01s)
=== RUN   TestAccBigipSysProvision_create
--- PASS: TestAccBigipSysProvision_create (0.42s)
=== RUN   TestAccBigipSysProvision_import
--- PASS: TestAccBigipSysProvision_import (0.74s)
=== RUN   TestAccBigipSyssnmp_create
--- PASS: TestAccBigipSyssnmp_create (1.19s)
=== RUN   TestAccBigipSyssnmp_import
--- PASS: TestAccBigipSyssnmp_import (0.61s)
=== RUN   TestValidStringValue
--- PASS: TestValidStringValue (0.00s)
=== RUN   TestInvalidStringValue
--- PASS: TestInvalidStringValue (0.00s)
=== RUN   TestF5NameString
--- PASS: TestF5NameString (0.00s)
=== RUN   TestF5NameSet
--- PASS: TestF5NameSet (0.00s)
=== RUN   TestF5NameList
--- PASS: TestF5NameList (0.00s)
=== RUN   TestValidateEnabledDisabledString
--- PASS: TestValidateEnabledDisabledString (0.00s)
=== RUN   TestValidateReqPrefDisabledString
--- PASS: TestValidateReqPrefDisabledString (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-bigip/bigip   65.240s

```