### PR TITLE
changing required parameters to optional in _bigip_ltm_policy

### DIFF
--- a/bigip/resource_bigip_ltm_policy.go
+++ b/bigip/resource_bigip_ltm_policy.go
@@ -43,14 +43,14 @@ func resourceBigipLtmPolicy() *schema.Resource {
 				Type:     schema.TypeSet,
 				Set:      schema.HashString,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Required: true,
+				Optional: true,
 			},
 
 			"requires": {
 				Type:     schema.TypeSet,
 				Set:      schema.HashString,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Required: true,
+				Optional: true,
 			},
 
 			"strategy": {
@@ -62,7 +62,7 @@ func resourceBigipLtmPolicy() *schema.Resource {
 
 			"rule": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -1068,6 +1068,9 @@ func resourceBigipLtmPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 	published_copy := d.Get("published_copy").(string)
+        if published_copy == "" {
+		published_copy =  "Drafts/" + name
+	}
 	t := client.PublishPolicy(name, published_copy)
 	if t != nil {
 		return t

--- a/bigip/resource_bigip_ltm_policy.go
+++ b/bigip/resource_bigip_ltm_policy.go
@@ -1068,8 +1068,8 @@ func resourceBigipLtmPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 	published_copy := d.Get("published_copy").(string)
-        if published_copy == "" {
-		published_copy =  "Drafts/" + name
+	if published_copy == "" {
+		published_copy = "Drafts/" + name
 	}
 	t := client.PublishPolicy(name, published_copy)
 	if t != nil {


### PR DESCRIPTION
For creating bigip ltm policy, only name is required parameter and rules, controls are optional parameters. This is already documented in terraform documentation but the code is not updated accordingly. Hence changing the code in bigip/resource_bigip_ltm_policy.go to optional .
Since published_copy is optional, and if user is not providing any input to it, we are handling with default value ( Drafts/Policy_name )