### PR TITLE
fix policy uploading to defined partition

### DIFF
--- a/bigip/provider.go
+++ b/bigip/provider.go
@@ -158,11 +158,16 @@ func mapEntity(d map[string]interface{}, obj interface{}) {
 				f.Set(reflect.ValueOf(d[field]))
 			}
 		} else {
-			if field == "http_reply" {
-				f := val.FieldByName(strings.Title("httpReply"))
-				f.Set(reflect.ValueOf(d[field]))
+			if strings.Contains(field, "_") {
+				f := val.FieldByName(strings.Title(snakeCaseToCamelCase(field)))
+				if f.IsValid() {
+					f.Set(reflect.ValueOf(d[field]))
+				} else {
+					log.Printf("[WARN] You probably weren't expecting %s to be an invalid field", field)
+				}
+			} else {
+				log.Printf("[WARN] You probably weren't expecting %s to be an invalid field", field)
 			}
-			log.Printf("[WARN] You probably weren't expecting %s to be an invalid field", field)
 		}
 	}
 }
@@ -174,4 +179,29 @@ func parseF5Identifier(str string) (partition, name string) {
 		return ary[0], ary[1]
 	}
 	return "", str
+}
+
+func snakeCaseToCamelCase(inputUnderScoreStr string) (camelCase string) {
+	//snake_case to camelCase
+
+	isToUpper := false
+
+	for k, v := range inputUnderScoreStr {
+		if k == 0 {
+			camelCase = string(inputUnderScoreStr[0])
+		} else {
+			if isToUpper {
+				camelCase += strings.ToUpper(string(v))
+				isToUpper = false
+			} else {
+				if v == '_' {
+					isToUpper = true
+				} else {
+					camelCase += string(v)
+				}
+			}
+		}
+	}
+	return
+
 }

--- a/bigip/resource_bigip_ltm_policy.go
+++ b/bigip/resource_bigip_ltm_policy.go
@@ -39,6 +39,14 @@ func resourceBigipLtmPolicy() *schema.Resource {
 				ForceNew:    true,
 			},
 
+			"partition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Publish to partition",
+				Default:     "/Common",
+				ForceNew:    true,
+			},
+
 			"controls": {
 				Type:     schema.TypeSet,
 				Set:      schema.HashString,
@@ -254,7 +262,6 @@ func resourceBigipLtmPolicy() *schema.Resource {
 									"http_host": {
 										Type:     schema.TypeBool,
 										Optional: true,
-										//Computed: true,
 									},
 									"http_referer": {
 										Type:     schema.TypeBool,
@@ -1067,12 +1074,11 @@ func resourceBigipLtmPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return err
 	}
-	published_copy := d.Get("published_copy").(string)
-	if published_copy == "" {
-		published_copy = "Drafts/" + name
-	}
-	t := client.PublishPolicy(name, published_copy)
+	draft_copy := "/" + d.Get("partition").(string) + "/Drafts/" + d.Get("name").(string)
+	t := client.PublishPolicy(name, draft_copy)
 	if t != nil {
+		log.Println("[WARN] Error on Create Policy: " + name)
+		log.Printf("%#v", t)
 		return t
 	}
 	return resourceBigipLtmPolicyRead(d, meta)
@@ -1080,7 +1086,7 @@ func resourceBigipLtmPolicyCreate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceBigipLtmPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*bigip.BigIP)
-	name := d.Id()
+	name := "/" + d.Get("partition").(string) + "/" + d.Id()
 
 	log.Println("[INFO] Fetching policy " + name)
 	p, err := client.GetPolicy(name)
@@ -1102,7 +1108,7 @@ func resourceBigipLtmPolicyRead(d *schema.ResourceData, meta interface{}) error 
 func resourceBigipLtmPolicyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	client := meta.(*bigip.BigIP)
 
-	name := d.Id()
+	name := "/" + d.Get("partition").(string) + "/" + d.Id()
 	log.Println("[INFO] Fetching policy " + name)
 	p, err := client.GetPolicy(name)
 	if err != nil {
@@ -1122,17 +1128,28 @@ func resourceBigipLtmPolicyUpdate(d *schema.ResourceData, meta interface{}) erro
 	name := d.Id()
 	log.Println("[INFO] Updating  Policy " + name)
 	p := dataToPolicy(name, d)
+
+	i := client.CreatePolicyDraft("/" + d.Get("partition").(string) + "/" + name)
+	if i != nil {
+		return i
+	}
 	err := client.UpdatePolicy(name, &p)
 	if err != nil {
 		log.Printf("[ERROR] Unable to Retrieve Policy   (%s) (%v) ", name, err)
 		return err
+	}
+
+	draft_copy := "/" + d.Get("partition").(string) + "/Drafts/" + d.Get("name").(string)
+	t := client.PublishPolicy(name, draft_copy)
+	if t != nil {
+		return t
 	}
 	return resourceBigipLtmPolicyRead(d, meta)
 }
 
 func resourceBigipLtmPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*bigip.BigIP)
-	name := d.Id()
+	name := "/" + d.Get("partition").(string) + "/" + d.Id()
 	err := client.DeletePolicy(name)
 	if err != nil {
 		log.Printf("[ERROR] Unable to Delete Policy   (%s) (%v) ", name, err)
@@ -1151,6 +1168,7 @@ func dataToPolicy(name string, d *schema.ResourceData) bigip.Policy {
 	result := strings.Join(values, "")
 	p.Name = result
 	p.Strategy = d.Get("strategy").(string)
+	p.Partition = "/" + d.Get("partition").(string)
 	p.Controls = setToStringSlice(d.Get("controls").(*schema.Set))
 	p.Requires = setToStringSlice(d.Get("requires").(*schema.Set))
 	ruleCount := d.Get("rule.#").(int)
@@ -1177,7 +1195,6 @@ func dataToPolicy(name string, d *schema.ResourceData) bigip.Policy {
 		}
 		p.Rules = append(p.Rules, r)
 	}
-
 	return p
 }
 
@@ -1190,6 +1207,9 @@ func policyToData(p *bigip.Policy, d *schema.ResourceData) error {
 	}
 	if err := d.Set("requires", makeStringSet(&p.Requires)); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving Requires  state for Policy (%s): %s", d.Id(), err)
+	}
+	if err := d.Set("partition", p.Partition); err != nil {
+		return fmt.Errorf("[DEBUG] Error saving Partition   state for Policy (%s): %s", d.Id(), err)
 	}
 
 	for i, r := range p.Rules {

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -586,17 +586,18 @@ type VirtualServerPolicies struct {
 }
 
 type PolicyPublish struct {
-	Name        string
-	Command     string
+	Name    string
+	Command string
 }
 type PolicyPublishDTO struct {
-	Name        string `json:"name"`
-	Command     string `json:"command"`
+	Name    string `json:"name"`
+	Command string `json:"command"`
 }
+
 func (p *PolicyPublish) MarshalJSON() ([]byte, error) {
 	return json.Marshal(PolicyPublishDTO{
-		Name:        p.Name,
-		Command:     p.Command,
+		Name:    p.Name,
+		Command: p.Command,
 	})
 }
 func (p *PolicyPublish) UnmarshalJSON(b []byte) error {
@@ -609,6 +610,7 @@ func (p *PolicyPublish) UnmarshalJSON(b []byte) error {
 	p.Command = dto.Command
 	return nil
 }
+
 type Policy struct {
 	Name        string
 	PublishCopy string
@@ -667,14 +669,14 @@ func (p *Policy) UnmarshalJSON(b []byte) error {
 }
 
 type VirtualServerPolicy struct {
-	Name        string
-	Partition   string
-	FullPath    string
+	Name      string
+	Partition string
+	FullPath  string
 }
 type VirtualServerPolicyDTO struct {
-	Name        string   `json:"name"`
-	Partition   string   `json:"partition,omitempty"`
-	FullPath    string   `json:"fullPath,omitempty"`
+	Name      string `json:"name"`
+	Partition string `json:"partition,omitempty"`
+	FullPath  string `json:"fullPath,omitempty"`
 }
 
 type PolicyRules struct {
@@ -1728,6 +1730,7 @@ const (
 	uriSourceAddr     = "source-addr"
 	uriSSL            = "ssl"
 	uriUniversal      = "universal"
+	uriCreateDraft    = "?options=create-draft"
 )
 
 var cidr = map[string]string{
@@ -1937,7 +1940,7 @@ func (b *BigIP) AddNode(config *Node) error {
 }
 
 // CreateNode adds a new IP based node to the BIG-IP system.
-func (b *BigIP) CreateNode(name, address, rate_limit string, connection_limit, dynamic_ratio int, monitor, state ,description string) error {
+func (b *BigIP) CreateNode(name, address, rate_limit string, connection_limit, dynamic_ratio int, monitor, state, description string) error {
 	config := &Node{
 		Name:            name,
 		Address:         address,
@@ -2313,7 +2316,12 @@ func (b *BigIP) VirtualServerPolicyNames(vs string) ([]string, error) {
 	}
 	retval := make([]string, 0, len(policies.PolicyRef))
 	for _, p := range policies.PolicyRef {
-		retval = append(retval, p.Name)
+		//if the policy is attached to a partition append its partition to the name
+		if p.Partition != "" {
+			retval = append(retval, "/" + p.Partition + "/" + p.Name)
+		} else {
+			retval = append(retval, p.Name)
+		}
 	}
 	return retval, nil
 }
@@ -2575,7 +2583,7 @@ func (b *BigIP) CreatePolicy(p *Policy) error {
 
 func (b *BigIP) PublishPolicy(name, publish string) error {
 	config := &PolicyPublish{
-		Name: publish,
+		Name:    publish,
 		Command: "publish",
 	}
 	values := []string{}
@@ -2593,6 +2601,11 @@ func (b *BigIP) PublishPolicy(name, publish string) error {
 func (b *BigIP) UpdatePolicy(name string, p *Policy) error {
 	normalizePolicy(p)
 	values := []string{}
+	//The terraform provider always sets the default partition
+	// However need to add this check for backwards compat.
+	if p.Partition != "" {
+		values = append(values, p.Partition + "/")
+	}
 	values = append(values, "Drafts/")
 	values = append(values, name)
 	// Join three strings into one.
@@ -2608,6 +2621,16 @@ func (b *BigIP) DeletePolicy(name string) error {
 	// Join three strings into one.
 	//result := strings.Join(values, "")
 	return b.delete(uriLtm, uriPolicy, name)
+}
+
+//Create a draft from an existing policy
+func (b *BigIP) CreatePolicyDraft(name string) error {
+	var s struct{}
+	values := []string{}
+	values = append(values, name)
+	values = append(values, uriCreateDraft)
+	result := strings.Join(values, "")
+	return b.patch(s, uriLtm, uriPolicy, result)
 }
 
 // Oneconnect profile creation


### PR DESCRIPTION
This pull request allows one to upload policies to specific partitions.

Here's some example code that I used to test it.

```hcl
resource "bigip_ltm_policy" "my_test_policy" {
  name = "my_test_policy"
  strategy = "/Common/best-match"
  partition = "Terraform"
  requires = ["https"]
  published_copy = "/Terraform/Drafts/my_test_policy"
  controls = ["forwarding"]
  rule {
    name = "my_test_rule"

    condition {
      http_uri = true
      path = true
      starts_with = true
      values = [ "/api/" ]
      request = true
    }   

    action {
      forward = true
      pool = "/Terraform/my_test_pool"
      request = true
    }   
  }
}
```

fixes #135 