### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Clone repository to: $GOPATH/src/github.com/terraform-providers/terraform-provid
 
 ```
 $ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-bigip
+$ git clone https://github.com/terraform-providers/terraform-provider-bigip.git
 
 ```
 Enter the provider directory and build the provider


### PR DESCRIPTION
This will fix repository cloning, error message was:

```$  git clone github.com:terraform-providers/terraform-provider-bigip
Cloning into 'terraform-provider-bigip'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```