### PR TITLE
send datagroup type with the update API content

### DIFF
--- a/bigip/resource_bigip_ltm_datagroup.go
+++ b/bigip/resource_bigip_ltm_datagroup.go
@@ -161,6 +161,7 @@ func resourceBigipLtmDataGroupUpdate(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Modifying Data Group List %s", name)
 
 	rs := d.Get("record").(*schema.Set)
+	dgtype := d.Get("type").(string)
 
 	var records []bigip.DataGroupRecord
 	if rs.Len() > 0 {
@@ -172,7 +173,7 @@ func resourceBigipLtmDataGroupUpdate(d *schema.ResourceData, meta interface{}) e
 		records = nil
 	}
 
-	err := client.ModifyInternalDataGroupRecords(name, records)
+	err := client.ModifyInternalDataGroupRecords(name, dgtype, records)
 	if err != nil {
 		return fmt.Errorf("Error modifying Data Group List %s: %v", name, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,3 @@ require (
 	github.com/stretchr/testify v1.3.0
 	google.golang.org/genproto v0.0.0-20190306203927-b5d61aea6440 // indirect
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require (
 	github.com/stretchr/testify v1.3.0
 	google.golang.org/genproto v0.0.0-20190306203927-b5d61aea6440 // indirect
 )
+
+go 1.13

--- a/vendor/github.com/f5devcentral/go-bigip/ltm.go
+++ b/vendor/github.com/f5devcentral/go-bigip/ltm.go
@@ -7,9 +7,9 @@ You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and limitations under the License.
- */
+*/
 /*
-Original work Copyright © 2015 Scott Ware 
+Original work Copyright © 2015 Scott Ware
 Licensed under the Apache License, Version 2.0 (the "License");
 You may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -610,17 +610,18 @@ type VirtualServerPolicies struct {
 }
 
 type PolicyPublish struct {
-	Name        string
-	Command     string
+	Name    string
+	Command string
 }
 type PolicyPublishDTO struct {
-	Name        string `json:"name"`
-	Command     string `json:"command"`
+	Name    string `json:"name"`
+	Command string `json:"command"`
 }
+
 func (p *PolicyPublish) MarshalJSON() ([]byte, error) {
 	return json.Marshal(PolicyPublishDTO{
-		Name:        p.Name,
-		Command:     p.Command,
+		Name:    p.Name,
+		Command: p.Command,
 	})
 }
 func (p *PolicyPublish) UnmarshalJSON(b []byte) error {
@@ -633,6 +634,7 @@ func (p *PolicyPublish) UnmarshalJSON(b []byte) error {
 	p.Command = dto.Command
 	return nil
 }
+
 type Policy struct {
 	Name        string
 	PublishCopy string
@@ -691,14 +693,14 @@ func (p *Policy) UnmarshalJSON(b []byte) error {
 }
 
 type VirtualServerPolicy struct {
-	Name        string
-	Partition   string
-	FullPath    string
+	Name      string
+	Partition string
+	FullPath  string
 }
 type VirtualServerPolicyDTO struct {
-	Name        string   `json:"name"`
-	Partition   string   `json:"partition,omitempty"`
-	FullPath    string   `json:"fullPath,omitempty"`
+	Name      string `json:"name"`
+	Partition string `json:"partition,omitempty"`
+	FullPath  string `json:"fullPath,omitempty"`
 }
 
 type PolicyRules struct {
@@ -1961,7 +1963,7 @@ func (b *BigIP) AddNode(config *Node) error {
 }
 
 // CreateNode adds a new IP based node to the BIG-IP system.
-func (b *BigIP) CreateNode(name, address, rate_limit string, connection_limit, dynamic_ratio int, monitor, state ,description string, ratio int) error {
+func (b *BigIP) CreateNode(name, address, rate_limit string, connection_limit, dynamic_ratio int, monitor, state, description string, ratio int) error {
 	config := &Node{
 		Name:            name,
 		Address:         address,
@@ -2063,9 +2065,10 @@ func (b *BigIP) DeleteInternalDataGroup(name string) error {
 }
 
 // Modify a named internal data group, REPLACING all the records
-func (b *BigIP) ModifyInternalDataGroupRecords(name string, records []DataGroupRecord) error {
+func (b *BigIP) ModifyInternalDataGroupRecords(name, dgtype string, records []DataGroupRecord) error {
 	config := &DataGroup{
 		Records: records,
+		Type:    dgtype,
 	}
 	return b.put(config, uriLtm, uriDatagroup, uriInternal, name)
 }
@@ -2601,7 +2604,7 @@ func (b *BigIP) CreatePolicy(p *Policy) error {
 
 func (b *BigIP) PublishPolicy(name, publish string) error {
 	config := &PolicyPublish{
-		Name: publish,
+		Name:    publish,
 		Command: "publish",
 	}
 	values := []string{}


### PR DESCRIPTION
fixes #180 

Due to https://techdocs.f5.com/kb/en-us/products/big-ip_ltm/releasenotes/related/relnote-supplement-bigip-14-1-0-1.html#A742170-2 the `type` of the datagroup must be sent in the update API content.

@scshitole @papineni87 @GaddamSaketha FYI, since the upstream go-bigip is stale I just updated the relevant code in vendor directly, but we should make sure that go-bigip is up-2-date with all the recent changes.