### PR TITLE
Fixed cert/key copying issues

### DIFF
--- a/bigip/resource_bigip_ssl_certificate.go
+++ b/bigip/resource_bigip_ssl_certificate.go
@@ -5,7 +5,6 @@ import (
 	"github.com/f5devcentral/go-bigip"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
-	"strings"
 )
 
 func resourceBigipSslCertificate() *schema.Resource {
@@ -35,10 +34,11 @@ func resourceBigipSslCertificate() *schema.Resource {
 			},
 
 			"partition": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "Common",
-				Description: "Partition of ssl certificate",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "Common",
+				Description:  "Partition of ssl certificate",
+				ValidateFunc: validatePartitionName,
 			},
 		},
 	}
@@ -48,12 +48,10 @@ func resourceBigipSslCertificateCreate(d *schema.ResourceData, meta interface{})
 	client := meta.(*bigip.BigIP)
 	name := d.Get("name").(string)
 	log.Println("[INFO] Certificate Name " + name)
-	if !strings.HasSuffix(name, ".crt") {
-		name = name + ".crt"
-	}
-	certpath := d.Get("content").(string)
+
+	certPath := d.Get("content").(string)
 	partition := d.Get("partition").(string)
-	err := client.UploadCertificate(name, certpath, partition)
+	err := client.UploadCertificate(name, certPath, partition)
 	if err != nil {
 		return fmt.Errorf("Error in Importing certificate (%s): %s", name, err)
 	}
@@ -66,10 +64,7 @@ func resourceBigipSslCertificateRead(d *schema.ResourceData, meta interface{}) e
 	name := d.Id()
 	log.Println("[INFO] Reading Certificate : " + name)
 	partition := d.Get("partition").(string)
-	if !strings.HasSuffix(name, ".crt") {
-		name = name + ".crt"
-	}
-	name = "~" + partition + "~" + name
+	name = "/" + partition + "/" + name
 	certificate, err := client.GetCertificate(name)
 	log.Printf("[INFO] Certificate content:%+v", certificate)
 	d.Set("name", certificate.Name)
@@ -85,10 +80,8 @@ func resourceBigipSslCertificateExists(d *schema.ResourceData, meta interface{})
 	name := d.Id()
 	log.Println("[INFO] Checking certificate " + name + " exists.")
 	partition := d.Get("partition").(string)
-	if !strings.HasSuffix(name, ".crt") {
-		name = name + ".crt"
-	}
-	name = "~" + partition + "~" + name
+
+	name = "/" + partition + "/" + name
 	certificate, err := client.GetCertificate(name)
 	if err != nil {
 		log.Printf("[ERROR] Unable to Retrieve certificate   (%s) (%v) ", name, err)
@@ -109,9 +102,9 @@ func resourceBigipSslCertificateUpdate(d *schema.ResourceData, meta interface{})
 	log.Println("[INFO] Certificate Name " + name)
 	certpath := d.Get("content").(string)
 	partition := d.Get("partition").(string)
-	if !strings.HasSuffix(name, ".crt") {
+	/*if !strings.HasSuffix(name, ".crt") {
 		name = name + ".crt"
-	}
+	}*/
 	err := client.UpdateCertificate(name, certpath, partition)
 	if err != nil {
 		return fmt.Errorf("Error in Importing certificate (%s): %s", name, err)
@@ -125,10 +118,10 @@ func resourceBigipSslCertificateDelete(d *schema.ResourceData, meta interface{})
 	name := d.Id()
 	log.Println("[INFO] Deleting Certificate " + name)
 	partition := d.Get("partition").(string)
-	if !strings.HasSuffix(name, ".crt") {
+	/*if !strings.HasSuffix(name, ".crt") {
 		name = name + ".crt"
-	}
-	name = "~" + partition + "~" + name
+	}*/
+	name = "/" + partition + "/" + name
 	err := client.DeleteCertificate(name)
 	if err != nil {
 		log.Printf("[ERROR] Unable to Delete Pool   (%s) (%v) ", name, err)

--- a/bigip/validators.go
+++ b/bigip/validators.go
@@ -64,6 +64,34 @@ func validateF5Name(value interface{}, field string) (ws []string, errors []erro
 	return
 }
 
+func validatePartitionName(value interface{}, field string) (ws []string, errors []error) {
+	var values []string
+	switch value.(type) {
+	case *schema.Set:
+		values = setToStringSlice(value.(*schema.Set))
+		break
+	case []string:
+		values = value.([]string)
+		break
+	case *[]string:
+		values = *(value.(*[]string))
+		break
+	case string:
+		values = []string{value.(string)}
+		break
+	default:
+		errors = append(errors, fmt.Errorf("Unknown type %v in validatePartitionName", reflect.TypeOf(value)))
+	}
+
+	for _, v := range values {
+		match, _ := regexp.MatchString(`^[^/][^\s]+$`, v)
+		if !match {
+			errors = append(errors, fmt.Errorf("%q name should not start with `/`, e.g Common [or] test-partition are valid ", field))
+		}
+	}
+	return
+}
+
 func validatePoolMemberName(value interface{}, field string) (ws []string, errors []error) {
 	var values []string
 	switch value.(type) {


### PR DESCRIPTION
**Acceptance Test Results:**
```
=== RUN   TestAccProvider
--- PASS: TestAccProvider (0.00s)
=== RUN   TestAccBigipAs3_create
--- PASS: TestAccBigipAs3_create (12.82s)
=== RUN   TestAccBigipAs3_badJSON
--- PASS: TestAccBigipAs3_badJSON (0.02s)
=== RUN   TestAccBigipCmDevice_create
--- PASS: TestAccBigipCmDevice_create (3.38s)
=== RUN   TestAccBigipCmDevice_import
--- PASS: TestAccBigipCmDevice_import (1.05s)
=== RUN   TestAccBigipCmDevicegroup_create
--- PASS: TestAccBigipCmDevicegroup_create (3.24s)
=== RUN   TestAccBigipCmDevicegroup_import
--- PASS: TestAccBigipCmDevicegroup_import (0.73s)
=== RUN   TestAccBigipLtmDataGroup_create
--- PASS: TestAccBigipLtmDataGroup_create (3.46s)
=== RUN   TestAccBigipLtmDataGroup_import
--- PASS: TestAccBigipLtmDataGroup_import (2.12s)
=== RUN   TestAccBigipLtmIRule_create
--- PASS: TestAccBigipLtmIRule_create (1.32s)
=== RUN   TestAccBigipLtmIRule_import
--- PASS: TestAccBigipLtmIRule_import (0.50s)
=== RUN   TestAccBigipLtmMonitor_create
--- PASS: TestAccBigipLtmMonitor_create (6.56s)
=== RUN   TestAccBigipLtmMonitor_import
--- PASS: TestAccBigipLtmMonitor_import (1.38s)
=== RUN   TestAccBigipLtmNode_create
--- PASS: TestAccBigipLtmNode_create (1.05s)
=== RUN   TestAccBigipLtmNode_import
--- PASS: TestAccBigipLtmNode_import (1.50s)
=== RUN   TestAccBigipLtmNodeInvalid
--- PASS: TestAccBigipLtmNodeInvalid (0.01s)
=== RUN   TestAccBigipLtmNodeCreate
--- PASS: TestAccBigipLtmNodeCreate (0.11s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieCreate
--- PASS: TestAccBigipLtmPersistenceProfileCookieCreate (0.99s)
=== RUN   TestAccBigipLtmPersistenceProfileCookieImport
--- PASS: TestAccBigipLtmPersistenceProfileCookieImport (0.71s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrCreate (0.64s)
=== RUN   TestAccBigipLtmPersistenceProfileDstAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileDstAddrImport (0.66s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrCreate
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrCreate (0.87s)
=== RUN   TestAccBigipLtmPersistenceProfileSrcAddrImport
--- PASS: TestAccBigipLtmPersistenceProfileSrcAddrImport (0.91s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLCreate
--- PASS: TestAccBigipLtmPersistenceProfileSSLCreate (0.99s)
=== RUN   TestAccBigipLtmPersistenceProfileSSLImport
--- PASS: TestAccBigipLtmPersistenceProfileSSLImport (0.93s)
=== RUN   TestAccBigipLtmPolicy_create
--- PASS: TestAccBigipLtmPolicy_create (1.90s)
=== RUN   TestAccBigipLtmPolicy_import
--- PASS: TestAccBigipLtmPolicy_import (1.80s)
=== RUN   TestAccBigipLtmPool_create
--- PASS: TestAccBigipLtmPool_create (0.89s)
=== RUN   TestAccBigipLtmPool_import
--- PASS: TestAccBigipLtmPool_import (0.91s)
=== RUN   TestAccBigipLtmfasthttp_create
--- PASS: TestAccBigipLtmfasthttp_create (0.74s)
=== RUN   TestAccBigipLtmProfilefasthttp_import
--- PASS: TestAccBigipLtmProfilefasthttp_import (1.15s)
=== RUN   TestAccBigipLtmProfileFastl4_create
--- PASS: TestAccBigipLtmProfileFastl4_create (0.54s)
=== RUN   TestAccBigipLtmProfileFastl4_import
--- PASS: TestAccBigipLtmProfileFastl4_import (1.04s)
=== RUN   TestAccBigipLtmProfileHttp2_create
--- PASS: TestAccBigipLtmProfileHttp2_create (0.56s)
=== RUN   TestAccBigipLtmProfileHttp2_modify
--- PASS: TestAccBigipLtmProfileHttp2_modify (0.95s)
=== RUN   TestAccBigipLtmProfileHttp2_import
--- PASS: TestAccBigipLtmProfileHttp2_import (0.52s)
=== RUN   TestAccBigipLtmProfilehttp_create
--- PASS: TestAccBigipLtmProfilehttp_create (0.68s)
=== RUN   TestAccBigipLtmProfilehttp_import
--- PASS: TestAccBigipLtmProfilehttp_import (0.71s)
=== RUN   TestAccBigipLtmProfileHttpcompress_create
--- PASS: TestAccBigipLtmProfileHttpcompress_create (0.57s)
=== RUN   TestAccBigipLtmProfileHttpcompress_import
--- PASS: TestAccBigipLtmProfileHttpcompress_import (0.81s)
=== RUN   TestAccBigipLtmProfileoneconnect_create
--- PASS: TestAccBigipLtmProfileoneconnect_create (0.51s)
=== RUN   TestAccBigipLtmProfileoneconnect_import
--- PASS: TestAccBigipLtmProfileoneconnect_import (0.52s)
=== RUN   TestAccBigipLtmProfileClientSsl_create
--- PASS: TestAccBigipLtmProfileClientSsl_create (0.59s)
=== RUN   TestAccBigipLtmProfileClientSsl_import
--- PASS: TestAccBigipLtmProfileClientSsl_import (0.60s)
=== RUN   TestAccBigipLtmProfileServerSsl_create
--- PASS: TestAccBigipLtmProfileServerSsl_create (0.60s)
=== RUN   TestAccBigipLtmProfileServerSsl_import
--- PASS: TestAccBigipLtmProfileServerSsl_import (0.64s)
=== RUN   TestAccBigipLtmProfileTcp_create
--- PASS: TestAccBigipLtmProfileTcp_create (0.54s)
=== RUN   TestAccBigipLtmProfileTcp_import
--- PASS: TestAccBigipLtmProfileTcp_import (0.51s)
=== RUN   TestAccBigipLtmsnat_create
--- PASS: TestAccBigipLtmsnat_create (0.53s)
=== RUN   TestAccBigipLtmsnat_import
--- PASS: TestAccBigipLtmsnat_import (0.56s)
=== RUN   TestAccBigipLtmsnatpool_create
--- PASS: TestAccBigipLtmsnatpool_create (0.51s)
=== RUN   TestAccBigipLtmsnatpool_import
--- PASS: TestAccBigipLtmsnatpool_import (0.59s)
=== RUN   TestAccBigipLtmVA_create
--- PASS: TestAccBigipLtmVA_create (0.58s)
=== RUN   TestAccBigipLtmVA_import
--- PASS: TestAccBigipLtmVA_import (0.67s)
=== RUN   TestAccBigipLtmVS_create
--- PASS: TestAccBigipLtmVS_create (1.74s)
=== RUN   TestAccBigipLtmVS_create_Defaultstate
--- PASS: TestAccBigipLtmVS_create_Defaultstate (0.86s)
=== RUN   TestAccBigipLtmVS_Modify_stateDisabledtoEnabled
--- PASS: TestAccBigipLtmVS_Modify_stateDisabledtoEnabled (1.55s)
=== RUN   TestAccBigipLtmVS_Modify_stateEnabledtoDisabled
--- PASS: TestAccBigipLtmVS_Modify_stateEnabledtoDisabled (1.50s)
=== RUN   TestAccBigipLtmVS_import
--- PASS: TestAccBigipLtmVS_import (1.81s)
=== RUN   TestAccBigipNetroute_create
--- PASS: TestAccBigipNetroute_create (1.03s)
=== RUN   TestAccBigipNetroute_import
--- PASS: TestAccBigipNetroute_import (0.98s)
=== RUN   TestAccBigipNetselfip_create
--- PASS: TestAccBigipNetselfip_create (1.13s)
=== RUN   TestAccBigipNetselfip_import
--- PASS: TestAccBigipNetselfip_import (2.13s)
=== RUN   TestAccBigipNetvlan_create
--- PASS: TestAccBigipNetvlan_create (2.61s)
=== RUN   TestAccBigipNetvlan_import
--- PASS: TestAccBigipNetvlan_import (2.65s)
=== RUN   TestAccSslCertificateImportToBigip
--- PASS: TestAccSslCertificateImportToBigip (0.65s)
=== RUN   TestAccSslKeyImportToBigip
--- PASS: TestAccSslKeyImportToBigip (0.65s)
=== RUN   TestAccBigipSysdns_create
--- PASS: TestAccBigipSysdns_create (62.26s)
=== RUN   TestAccBigipSysdns_import
--- PASS: TestAccBigipSysdns_import (4.01s)
=== RUN   TestAccBigipSysIapp_create
--- PASS: TestAccBigipSysIapp_create (3.61s)
=== RUN   TestAccBigipSysIapp_import
--- PASS: TestAccBigipSysIapp_import (0.93s)
=== RUN   TestAccBigipSysNtp_create
--- PASS: TestAccBigipSysNtp_create (2.44s)
=== RUN   TestAccBigipSysNtp_import
--- PASS: TestAccBigipSysNtp_import (1.18s)
=== RUN   TestAccBigipSysNtpInvalid
--- PASS: TestAccBigipSysNtpInvalid (0.01s)
=== RUN   TestAccBigipSysProvision_create
--- PASS: TestAccBigipSysProvision_create (0.41s)
=== RUN   TestAccBigipSysProvision_import
--- PASS: TestAccBigipSysProvision_import (1.00s)
=== RUN   TestAccBigipSyssnmp_create
--- PASS: TestAccBigipSyssnmp_create (1.35s)
=== RUN   TestAccBigipSyssnmp_import
--- PASS: TestAccBigipSyssnmp_import (0.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-bigip/bigip	164.805s
```